### PR TITLE
Fix Qrg Formula File.

### DIFF
--- a/qrg.rb
+++ b/qrg.rb
@@ -2,7 +2,7 @@ require "formula"
 
 HOMEBREW_QRG_VERSION="1.0.0"
 
-class Uniq2 < Formula
+class Qrg < Formula
   desc "QR code generator"
   homepage "https://github.com/tamada/qrg"
   url "https://github.com/tamada/qrg.git", :tag => "v#{HOMEBREW_QRG_VERSION}"


### PR DESCRIPTION
```
$ brew tap tamada/brew
==> Tapping tamada/brew
Cloning into '/usr/local/Homebrew/Library/Taps/tamada/homebrew-brew'...
remote: Enumerating objects: 7, done.
remote: Counting objects: 100% (7/7), done.
remote: Compressing objects: 100% (7/7), done.
remote: Total 7 (delta 3), reused 3 (delta 0), pack-reused 0
Unpacking objects: 100% (7/7), done.
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/tamada/homebrew-brew/qrg.rb
No available formula with the name "qrg"
In formula file: /usr/local/Homebrew/Library/Taps/tamada/homebrew-brew/qrg.rb
Expected to find class Qrg, but only found: Uniq2.
Error: Cannot tap tamada/brew: invalid syntax in tap!
```